### PR TITLE
feat: adds new (Component) Releases in order of SemVer 2.0 precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,16 @@ SPDX-License-Identifier: MIT
 # Jira Version Me
 
 JiraVersionMe provides a [GitHub Action](#github-action), and [Command Line Interface](./docs/cli.md) for managing Jira Versions.
+The created releases are sorted based on SemVer 2.0 precedence, allowing you to use JQL for queries such as:
 
+```
+project=TEST AND fixVersion >=1.0.0 AND fixVersion <2.0.0
+```
+
+> [!WARNING]
+> The action expects that the initial versions are already sorted correctly.
+>
+> If this is not the case, please use the provided [CLI tool to sort your project Versions](#sorting-all-releases).
 
 ## GitHub Action
 
@@ -30,17 +39,22 @@ jobs:
           project: PIPE
           version: '1.0.0'
 
+          # OPTIONAL: Component name to associate with the provided release (i.e. "framework" leading to "framework/1.0.0")
+          component: 'framework'
           # OPTIONAL: Description associated with the version
           description: 'Product launch milestone'
           # OPTIONAL: Mark the version as "Released"
           release: true
           # OPTIONAL: Assign the following list of issues to the version
           tickets: |
-            PIPE-213
-            PIPE-214  
+            TEST-123
+            TEST-456
 ```
 
 ## Command-line Interface
+
+Currently the CLI tool is not distributed as a stand-alone product.
+For now, please clone the repository on the expected version and run the binary (`./bin/jira-version-me`) from your local environment.
 
 ### Basic usage
 ```sh
@@ -57,7 +71,17 @@ Options:
 Commands:
   update [options]
   assign [options]
+  sort
   help [command]           display help for command
+```
+
+### Sorting all Releases
+
+```sh
+Usage: jira-version-me sort [options]
+
+Options:
+  -h, --help  display help for command
 ```
 
 ### Create or Update a Version
@@ -66,6 +90,7 @@ Commands:
 Usage: jira-version-me update [options]
 
 Options:
+  -c, --component <component>      The component to update
   -v, --version <version>          The version to create
   -d, --description <description>  The description of the version
   -r, --release                    Mark the version as released
@@ -78,9 +103,10 @@ Options:
 Usage: jira-version-me assign [options]
 
 Options:
-  -v, --version <version>   The version to assign tickets to
-  -t, --ticket <ticket...>  List of JIRA tickets to assign to the specified version
-  -h, --help                display help for command
+  -c, --component <component>  The component to update
+  -v, --version <version>      The version to assign tickets to
+  -t, --ticket <ticket...>     List of JIRA tickets to assign to the specified version
+  -h, --help                   display help for command
 ```
 
 ## Contributing

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Jira Project Key'
     required: true
 
+  component:
+    description: 'Component to associate with the provided release (i.e. "framework" leading to "framework/1.0.0")'
+    required: false
+
   version:
     description: 'Name of the Version to create or update'
     required: true

--- a/lib/action/index.js
+++ b/lib/action/index.js
@@ -1830,6 +1830,579 @@ function isLoopbackAddress(host) {
 
 /***/ }),
 
+/***/ 1842:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+/*
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+SPDX-License-Identifier: MIT
+*/
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.formatFromString = exports.CalVer = void 0;
+const utils_1 = __nccwpck_require__(3464);
+/**
+ * A simple CalVer implementation
+ * @class CalVer
+ * @member major Major version
+ * @member minor Minor version
+ * @member micro Micro version
+ * @member modifier Modifier
+ * @method toString Returns the CalVer as a string
+ * @method increment Increments the CalVer by the provided type
+ */
+class CalVer {
+    constructor(format, version, prefix) {
+        var _a, _b, _c, _d, _e, _f;
+        this.format = typeof format === "string" ? formatFromString(format) : format;
+        if (typeof version === "string") {
+            if (prefix !== undefined) {
+                if (!version.startsWith(prefix))
+                    throw new Error("Incorrect CalVer, missing prefix");
+                version = version.substring(prefix.length);
+            }
+            const groups = (_a = this.format.regex.exec(version)) === null || _a === void 0 ? void 0 : _a.groups;
+            if (groups === undefined) {
+                throw new Error("Could not parse CalVer");
+            }
+            this.prefix = prefix;
+            this.major = parseInt(groups.major);
+            this.minor = parseInt(groups.minor);
+            this.micro = parseInt(groups.micro);
+            this.modifier = groups.modifier;
+        }
+        else {
+            this.prefix = (_b = version === null || version === void 0 ? void 0 : version.prefix) !== null && _b !== void 0 ? _b : prefix;
+            this.major = (_c = version === null || version === void 0 ? void 0 : version.major) !== null && _c !== void 0 ? _c : 0;
+            this.minor = (_d = version === null || version === void 0 ? void 0 : version.minor) !== null && _d !== void 0 ? _d : 0;
+            this.micro = (_e = version === null || version === void 0 ? void 0 : version.micro) !== null && _e !== void 0 ? _e : (this.format.micro ? 0 : undefined);
+            this.modifier = (_f = version === null || version === void 0 ? void 0 : version.modifier) !== null && _f !== void 0 ? _f : undefined;
+        }
+    }
+    /**
+     * Increments the modifier (in format "key.value") by 1.
+     * If no modifier is available, it will return "build.1"
+     * @returns Incremented modifier
+     */
+    incrementModifier() {
+        if (this.modifier === undefined)
+            return "build.1";
+        const keyValue = (0, utils_1.getKeyValuePair)(this.modifier);
+        if (keyValue === undefined)
+            throw new Error("Cannot increment modifiers without a key/value pair");
+        return `${keyValue.key}.${keyValue.value + 1}`;
+    }
+    /**
+     * Updates versions associated with calendar items (i.e. YYYY, MM, WW, DD)
+     * in the provided CalVer format.
+     * @param format The CalVer format
+     * @returns The updated version based on the current date.
+     */
+    updateCalendar(format) {
+        if (format === undefined || ["MAJOR", "MINOR", "MICRO"].includes(format))
+            return;
+        if (format.includes("Y"))
+            return new Date().getFullYear();
+        if (format.includes("M"))
+            return new Date().getMonth() + 1;
+        if (format.includes("W"))
+            return (0, utils_1.getISO8601WeekNumber)();
+        if (format.includes("D"))
+            return new Date().getDate() + 1;
+        return;
+    }
+    /**
+     * Returns a string, where the value is formatted correctly based on the provided format.
+     * @param value Value to format
+     * @param format CalVer format to use
+     * @returns Formatted value
+     */
+    formatVersionCore(value, format) {
+        if (["MAJOR", "MINOR", "MICRO"].includes(format))
+            return value.toString();
+        if (format === "YYYY")
+            return value.toString().padStart(4, "0");
+        if (format === "0Y")
+            return value
+                .toString()
+                .substring(value.toString().length - 3)
+                .padStart(3, "0");
+        if (format.includes("0"))
+            return value
+                .toString()
+                .substring(value.toString().length - 2)
+                .padStart(2, "0");
+        return value.toString().substring(value.toString().length - 2);
+    }
+    /**
+     * Returns the CalVer as a string
+     * @returns CalVer as a string
+     */
+    toString() {
+        var _a;
+        let version = (_a = this.prefix) !== null && _a !== void 0 ? _a : "";
+        version += `${this.formatVersionCore(this.major, this.format.major)}.${this.formatVersionCore(this.minor, this.format.minor)}`;
+        if (this.micro !== undefined && this.format.micro !== undefined)
+            version += `.${this.formatVersionCore(this.micro, this.format.micro)}`;
+        if (this.modifier !== undefined)
+            version += `-${this.modifier}`;
+        return version;
+    }
+    /**
+     * Increments the CalVer by the provided type;
+     *   - "calendar": Increments the calendar (i.e. YYYY, MM, WW, DD)
+     *   - "major": Increments the major version
+     *   - "minor": Increments the minor version
+     *   - "micro": Increments the micro version
+     *   - "modifier": Increments the modifier
+     * @param type Type of increment
+     * @returns Incremented CalVer
+     */
+    increment(type) {
+        var _a, _b, _c, _d;
+        switch (type) {
+            case "CALENDAR": {
+                // Increment the calendar only, this allows us to validate whether the calendar has changed
+                const newVersion = new CalVer(this.format, {
+                    prefix: this.prefix,
+                    major: (_a = this.updateCalendar(this.format.major)) !== null && _a !== void 0 ? _a : this.major,
+                    minor: (_b = this.updateCalendar(this.format.minor)) !== null && _b !== void 0 ? _b : this.minor,
+                    micro: (_c = this.updateCalendar(this.format.micro)) !== null && _c !== void 0 ? _c : this.micro,
+                    modifier: this.modifier,
+                });
+                // Increment the modifier if the calendar has not changed
+                if (newVersion.isEqualTo(this))
+                    return new CalVer(this.format, { ...this, modifier: this.incrementModifier() });
+                // If the calendar items are updated, reset MAJOR, MINOR, MICRO...
+                for (const subtype of ["major", "minor", "micro"]) {
+                    const filter = Object.keys(this.format).filter(key => this.format[key] === subtype.toUpperCase());
+                    if (filter.length !== 1)
+                        continue;
+                    newVersion[filter[0].toLowerCase()] = 0;
+                }
+                // ... and MODIFIER
+                newVersion.modifier = undefined;
+                return newVersion;
+            }
+            case "MAJOR":
+            case "MINOR":
+            case "MICRO": {
+                const filter = Object.keys(this.format).filter(key => this.format[key] === type.toUpperCase());
+                if (filter.length !== 1)
+                    throw new Error(`Unable to increment ${type} version as it is not part of the format`);
+                const item = filter[0].toLowerCase();
+                if (item === "major")
+                    return new CalVer(this.format, { major: this.major + 1, modifier: undefined });
+                if (item === "minor")
+                    return new CalVer(this.format, { major: this.major, minor: this.minor + 1, modifier: undefined });
+                if (item === "micro")
+                    return new CalVer(this.format, {
+                        major: this.major,
+                        minor: this.minor,
+                        micro: ((_d = this.micro) !== null && _d !== void 0 ? _d : 0) + 1,
+                        modifier: undefined,
+                    });
+                throw new Error("Unknown increment type.");
+            }
+            case "MODIFIER":
+                return new CalVer(this.format, { ...this, modifier: this.incrementModifier() });
+        }
+    }
+    /**
+     * Confirms that the provided format is identical to the current format
+     * @param other Other format to compare against
+     * @returns True if the formats are identical, false otherwise
+     */
+    isFormatIdentical(other) {
+        return this.format.major === other.major && this.format.minor === other.minor && this.format.micro === other.micro;
+    }
+    isEqualTo(other) {
+        return this.compareTo(other) === 0;
+    }
+    isGreaterThan(other) {
+        return this.compareTo(other) === 1;
+    }
+    isLessThan(other) {
+        return this.compareTo(other) === -1;
+    }
+    /**
+     * Returns 0 when current version is equal to the provided version,
+     * 1 when current version is greater than the provided version,
+     * and -1 when current version is less than the provided version.
+     *
+     * Resulting in the following ordering (taking `YYYY.0M.MICRO` as an example):
+     *
+     * 2022.03.1
+     * 2022.03.2
+     * 2022.11.1
+     * 2022.11.1-alpha.1
+     * 2022.11.1-alpha.2
+     * 2022.11.1-beta.1
+     * 2022.11.2
+     * 2023.01.1
+     *
+     * @param other CalVer to compare to
+     * @returns
+     */
+    compareTo(other) {
+        if (!this.isFormatIdentical(other.format))
+            throw new Error("Unable to compare CalVer with different formats");
+        if (this.major > other.major)
+            return 1;
+        if (this.major < other.major)
+            return -1;
+        if (this.minor > other.minor)
+            return 1;
+        if (this.minor < other.minor)
+            return -1;
+        if (this.micro !== undefined && other.micro !== undefined) {
+            if (this.micro > other.micro)
+                return 1;
+            if (this.micro < other.micro)
+                return -1;
+        }
+        if (this.modifier !== undefined && other.modifier === undefined)
+            return 1;
+        if (this.modifier === undefined && other.modifier !== undefined)
+            return -1;
+        if (this.modifier !== undefined && other.modifier !== undefined) {
+            const aModifier = (0, utils_1.getKeyValuePair)(this.modifier);
+            const bModifier = (0, utils_1.getKeyValuePair)(other.modifier);
+            if (aModifier !== undefined && bModifier !== undefined) {
+                if (aModifier.key !== bModifier.key)
+                    return aModifier.key.localeCompare(bModifier.key);
+                if (aModifier.value > bModifier.value)
+                    return 1;
+                if (aModifier.value < bModifier.value)
+                    return -1;
+            }
+            else {
+                return this.modifier.localeCompare(other.modifier);
+            }
+        }
+        return 0;
+    }
+}
+exports.CalVer = CalVer;
+/**
+ * Generates a regex based on the provided CalVer format
+ * @param format The CalVer format
+ * @returns The regex
+ * @internal
+ */
+function formatFromString(format) {
+    var _a;
+    const elements = (_a = /^(?<major>[A-Z0]+)\.(?<minor>[A-Z0]+)(\.(?<micro>[A-Z0]+))?$/.exec(format)) === null || _a === void 0 ? void 0 : _a.groups;
+    if (elements === undefined)
+        throw new Error(`Invalid CalVer format: ${format}`);
+    const usedElements = [];
+    const versions = [];
+    for (const key of Object.keys(elements)) {
+        if (elements[key] === undefined)
+            continue;
+        if (usedElements.includes(elements[key])) {
+            throw new Error(`Duplicate CalVer format element: ${elements[key]}`);
+        }
+        if (["MAJOR", "MINOR", "MICRO"].includes(elements[key]))
+            versions.push(`(?<${key}>\\d+)`);
+        else if (elements[key] === "YYYY")
+            versions.push(`(?<${key}>\\d{4})`);
+        else if (elements[key] === "YY")
+            versions.push(`(?<${key}>\\d{1,3})`);
+        else if (elements[key] === "0Y")
+            versions.push(`(?<${key}>\\d{3})`);
+        else if (["0M", "0W", "0D"].includes(elements[key]))
+            versions.push(`(?<${key}>\\d{2})`);
+        else if (["MM", "WW", "DD"].includes(elements[key]))
+            versions.push(`(?<${key}>\\d{1,2})`);
+        else
+            throw new Error(`Unknown CalVer format element: ${elements}, ${key}, ${elements[key]}`);
+        usedElements.push(elements[key]);
+    }
+    return {
+        regex: new RegExp(`^${versions.join(".")}(-(?<modifier>[\\w._]+))?$`),
+        major: elements.major,
+        minor: elements.minor,
+        micro: elements.micro,
+    };
+}
+exports.formatFromString = formatFromString;
+
+
+/***/ }),
+
+/***/ 4209:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+/*
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+SPDX-License-Identifier: MIT
+*/
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.CalVer = exports.SemVer = void 0;
+var semver_1 = __nccwpck_require__(292);
+Object.defineProperty(exports, "SemVer", ({ enumerable: true, get: function () { return semver_1.SemVer; } }));
+var calver_1 = __nccwpck_require__(1842);
+Object.defineProperty(exports, "CalVer", ({ enumerable: true, get: function () { return calver_1.CalVer; } }));
+
+
+/***/ }),
+
+/***/ 292:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+/*
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+SPDX-License-Identifier: MIT
+*/
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.SemVer = void 0;
+const assert_1 = __importDefault(__nccwpck_require__(9491));
+const utils_1 = __nccwpck_require__(3464);
+const SEMVER_REGEX = /^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<preRelease>[a-zA-Z0-9.-]+))?(\+(?<build>[a-zA-Z0-9.-]+))?$/;
+/**
+ * A simple SemVer implementation
+ * @class SemVer
+ * @implements ISemVer
+ * @member major Major version
+ * @member minor Minor version
+ * @member patch Patch version
+ * @member preRelease Pre-release identifier
+ * @member build Build identifier
+ * @method toString Returns the SemVer as a string
+ */
+class SemVer {
+    constructor(version, prefix) {
+        var _a, _b, _c, _d, _e;
+        if (typeof version === "string") {
+            // Handle prefix
+            if (prefix !== undefined) {
+                if (!version.startsWith(prefix))
+                    throw new Error("Incorrect SemVer, missing prefix");
+                version = version.substring(prefix.length);
+            }
+            // SemVer regex
+            const groups = (_a = SEMVER_REGEX.exec(version)) === null || _a === void 0 ? void 0 : _a.groups;
+            if (groups === undefined)
+                throw new Error("Could not parse SemVer");
+            this.prefix = prefix;
+            this.major = parseInt(groups.major);
+            this.minor = parseInt(groups.minor);
+            this.patch = parseInt(groups.patch);
+            this.preRelease = groups.preRelease;
+            this.build = groups.build;
+        }
+        else {
+            this.prefix = (_b = version === null || version === void 0 ? void 0 : version.prefix) !== null && _b !== void 0 ? _b : prefix;
+            this.major = (_c = version === null || version === void 0 ? void 0 : version.major) !== null && _c !== void 0 ? _c : 0;
+            this.minor = (_d = version === null || version === void 0 ? void 0 : version.minor) !== null && _d !== void 0 ? _d : 0;
+            this.patch = (_e = version === null || version === void 0 ? void 0 : version.patch) !== null && _e !== void 0 ? _e : 0;
+            this.preRelease = version === null || version === void 0 ? void 0 : version.preRelease;
+            this.build = version === null || version === void 0 ? void 0 : version.build;
+        }
+    }
+    /**
+     * Increments the value of the SemVer identifier
+     * @param identifier Identifier to increment
+     * @returns Incremented identifier, undefined when identifier does not exist
+     */
+    incrementIdentifier(identifier) {
+        if (this[identifier] === undefined)
+            return;
+        const keyValuePair = (0, utils_1.getKeyValuePair)(this[identifier]);
+        if ((keyValuePair === null || keyValuePair === void 0 ? void 0 : keyValuePair.key) === undefined || (keyValuePair === null || keyValuePair === void 0 ? void 0 : keyValuePair.value) === undefined)
+            throw new Error(`Unable to bump ${identifier}`);
+        return `${keyValuePair.key}.${keyValuePair.value + 1}`;
+    }
+    /**
+     * Increments the SemVer based on the provided type:
+     * - major: 1.0.0 => 2.0.0
+     * - minor: 1.0.0 => 1.1.0
+     * - patch: 1.0.0 => 1.0.1
+     * - preRelease: 1.0.0 => 1.0.0-rc.1
+     * - build: 1.0.0 => 1.0.0+build.1
+     *
+     * Incrementing a type will reset any lesser significant types (e.g. incrementing minor will reset patch, preRelease, and build).
+     *   order of significance: major > minor > patch > preRelease > build
+     *
+     * @param type Type of increment
+     * @returns Incremented SemVer
+     */
+    increment(type) {
+        var _a, _b;
+        switch (type) {
+            case "PRERELEASE":
+                return new SemVer({ ...this, preRelease: (_a = this.incrementIdentifier("preRelease")) !== null && _a !== void 0 ? _a : "rc.1", build: undefined });
+            case "BUILD":
+                return new SemVer({
+                    ...this,
+                    preRelease: this.preRelease,
+                    build: (_b = this.incrementIdentifier("build")) !== null && _b !== void 0 ? _b : "build.1",
+                });
+            case "MAJOR":
+                return new SemVer({ prefix: this.prefix, major: this.major + 1 });
+            case "MINOR":
+                return new SemVer({ prefix: this.prefix, major: this.major, minor: this.minor + 1 });
+            case "PATCH":
+                return new SemVer({ prefix: this.prefix, major: this.major, minor: this.minor, patch: this.patch + 1 });
+        }
+    }
+    compareIdentifier(a, b) {
+        if (a === b)
+            return 0;
+        if (!a)
+            return -1;
+        if (!b)
+            return 1;
+        const aId = (0, utils_1.getKeyValuePair)(a);
+        const bId = (0, utils_1.getKeyValuePair)(b);
+        if (!aId)
+            return bId ? -1 : a.localeCompare(b);
+        if (!bId)
+            return 1;
+        if (aId.key !== bId.key)
+            return a.localeCompare(b);
+        if (aId.value !== bId.value) {
+            (0, assert_1.default)(aId.value !== undefined && bId.value !== undefined);
+            return aId.value > bId.value ? 1 : -1;
+        }
+        return 0;
+    }
+    /**
+     * Returns 0 when current version is equal to the provided version,
+     * 1 when current version is greater than the provided version,
+     * and -1 when current version is less than the provided version.
+     *
+     * Resulting in the following ordering:
+     *
+     * 0.0.1
+     * 0.0.2
+     * 0.1.0
+     * 0.2.0-rc.1
+     * 0.2.0-rc.2
+     * 0.2.0
+     * 0.2.0+build.1
+     * 0.2.0+build.2
+     * 0.2.1-rc.1+build.1
+     * 0.2.1-rc.1+build.2
+     * 0.2.1-rc.2
+     * 1.0.0
+     *
+     * @param other SemVer to compare to
+     * @returns
+     */
+    compareTo(other) {
+        const keys = ["major", "minor", "patch"];
+        for (const key of keys) {
+            if (this[key] !== other[key]) {
+                return this[key] > other[key] ? 1 : -1;
+            }
+        }
+        // undefined, prerelease, build, prerelease + build
+        // prerelease
+        // build
+        // prerelease + build
+        const mapping = [
+            [0, 1, -1, 1],
+            [
+                -1,
+                this.compareIdentifier(this.preRelease, other.preRelease),
+                -1,
+                this.compareIdentifier(this.preRelease, other.preRelease) === 0
+                    ? this.compareIdentifier(this.build, other.build)
+                    : this.compareIdentifier(this.preRelease, other.preRelease),
+            ],
+            [1, 1, this.compareIdentifier(this.build, other.build), 1],
+            [
+                -1,
+                this.compareIdentifier(this.preRelease, other.preRelease) === 0
+                    ? 1
+                    : this.compareIdentifier(this.preRelease, other.preRelease),
+                -1,
+                this.compareIdentifier(this.preRelease, other.preRelease) === 0
+                    ? this.compareIdentifier(this.build, other.build)
+                    : this.compareIdentifier(this.preRelease, other.preRelease),
+            ],
+        ];
+        const getIndex = (item) => !item.preRelease && !item.build ? 0 : item.preRelease && !item.build ? 1 : !item.preRelease && item.build ? 2 : 3;
+        return mapping[getIndex(this)][getIndex(other)];
+    }
+    isEqualTo(other) {
+        return this.compareTo(other) === 0;
+    }
+    isGreaterThan(other) {
+        return this.compareTo(other) === 1;
+    }
+    isLessThan(other) {
+        return this.compareTo(other) === -1;
+    }
+    /**
+     * Returns the SemVer as a string
+     * @returns SemVer as a string
+     */
+    toString() {
+        return `${this.prefix !== undefined ? this.prefix : ""}${this.major}.${this.minor}.${this.patch}${this.preRelease ? "-" + this.preRelease : ""}${this.build ? "+" + this.build : ""}`;
+    }
+}
+exports.SemVer = SemVer;
+
+
+/***/ }),
+
+/***/ 3464:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+/*
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+SPDX-License-Identifier: MIT
+*/
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getISO8601WeekNumber = exports.getKeyValuePair = void 0;
+/**
+ * Returns a key-value pair from the provided identifier (e.g. alpha.1 => { key: "alpha.", value: 1 })
+ * @param identifier Identifier to parse (e.g. alpha.1)
+ * @returns Identifier value (e.g. 1)
+ * @internal
+ */
+function getKeyValuePair(value) {
+    const kvpRegex = /^([a-zA-Z-]+)[.]([0-9]+)$/;
+    const match = kvpRegex.exec(value !== null && value !== void 0 ? value : "");
+    if (match === null)
+        return;
+    return { key: match[1], value: parseInt(match[2]) };
+}
+exports.getKeyValuePair = getKeyValuePair;
+/**
+ * Returns the week number of the current date (ISO 8601)
+ * @returns The week number of the current date
+ * @internal
+ */
+function getISO8601WeekNumber() {
+    const date = new Date();
+    const dayNumber = (date.getDay() + 6) % 7;
+    date.setDate(date.getDate() - dayNumber + 3);
+    const firstThursday = date.valueOf();
+    date.setMonth(0, 1);
+    if (date.getDay() !== 4) {
+        date.setMonth(0, 1 + ((4 - date.getDay() + 7) % 7));
+    }
+    return 1 + Math.ceil((firstThursday - date.valueOf()) / 604800000);
+}
+exports.getISO8601WeekNumber = getISO8601WeekNumber;
+
+
+/***/ }),
+
 /***/ 4812:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
@@ -28450,6 +29023,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __importStar(__nccwpck_require__(2186));
 const jira_1 = __nccwpck_require__(2222);
+const utils = __importStar(__nccwpck_require__(1314));
 /**
  * Main entry point for the GitHub Action.
  */
@@ -28458,8 +29032,11 @@ async function run() {
         core.info("📔 JiraVersionMe - Jira Release Management");
         const project = core.getInput("project");
         const jiraToken = core.getInput("jira-token");
+        core.setSecret(jiraToken);
         const jiraUrl = core.getInput("jira-url");
+        const component = core.getInput("component");
         const version = core.getInput("version");
+        const componentVersion = utils.setComponentVersion(version, component);
         const description = core.getInput("description");
         const release = core.getBooleanInput("release") || false;
         const jira = new jira_1.JiraClient(jiraUrl, jiraToken);
@@ -28470,34 +29047,35 @@ async function run() {
         core.info(`Api Version: ${jira.apiVersion}`);
         core.endGroup();
         core.startGroup("📄 Version Configuration");
+        core.info(`Component: ${component}`);
         core.info(`Version: ${version}`);
         core.info(`Description: ${description}`);
         core.info(`Release: ${release}`);
         core.info(`Archive: false`);
         core.endGroup();
         await jira.createOrUpdateVersion(project, {
-            name: version,
+            name: componentVersion,
             description,
             archived: false,
             released: release,
             releaseDate: release ? new Date().toISOString() : undefined,
         });
-        core.info(`✅ Version ${version} is up-to-date!`);
+        core.info(`✅ Version ${componentVersion} is up-to-date!`);
         const tickets = core.getMultilineInput("ticket");
         let errorCount = 0;
         for (const ticket of tickets) {
             try {
-                await jira.assignTicketToVersion(ticket, version);
+                await jira.assignTicketToVersion(ticket, componentVersion);
             }
             catch (error) {
                 core.error(`❌ ${error.message}`);
                 errorCount++;
                 return;
             }
-            core.info(`✅ Issue ${ticket} assigned to version ${version} successfully!`);
+            core.info(`✅ Issue ${ticket} assigned to version ${componentVersion} successfully!`);
         }
         if (errorCount > 0) {
-            core.setFailed(`❌ ${errorCount} errors occurred while assigning tickets to version ${version}`);
+            core.setFailed(`❌ ${errorCount} errors occurred while assigning tickets to version ${componentVersion}`);
         }
     }
     catch (ex) {
@@ -28548,7 +29126,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.JiraClient = void 0;
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const core = __importStar(__nccwpck_require__(2186));
+const version_it_1 = __nccwpck_require__(4209);
 const axios_1 = __importDefault(__nccwpck_require__(8757));
+const utils = __importStar(__nccwpck_require__(1314));
 /**
  * Represents a Jira client for making API requests.
  */
@@ -28621,9 +29201,13 @@ class JiraClient {
      * @returns - A promise that resolves to the project information.
      */
     async getProject(project) {
-        return (await this.request("GET", `project/${project}`).catch(err => {
+        const projectData = (await this.request("GET", `project/${project}`).catch(err => {
             throw new Error(err.response.data.errorMessages.join(", "));
         })).data;
+        if (typeof projectData === "string") {
+            throw new Error(`Unable to retrieve the Jira project ${project}.`);
+        }
+        return projectData;
     }
     /**
      * Creates or updates a version in a project.
@@ -28633,9 +29217,6 @@ class JiraClient {
      */
     async createOrUpdateVersion(project, version) {
         const projectData = await this.getProject(project);
-        if (typeof projectData === "string") {
-            throw new Error(`Unable to retrieve the Jira project ${project}.`);
-        }
         for (const v of projectData.versions || []) {
             if (version.name === v.name) {
                 core.info(`ℹ️  Version ${version.name} already exists in project ${project}, updating....`);
@@ -28646,13 +29227,28 @@ class JiraClient {
             }
         }
         core.info(`ℹ️  Creating version ${version.name} in project ${project}...`);
-        await this.request("POST", "version", {
+        const newVersion = (await this.request("POST", "version", {
             ...version,
             project: project,
             projectId: projectData.id,
         }).catch(err => {
             throw new Error(err.response.data.errorMessages.join(", "));
-        });
+        })).data;
+        const sortedVersions = utils
+            .sortFixVersions(projectData.versions)
+            .filter(v => utils.getComponentVersion(v.name).component === utils.getComponentVersion(newVersion.name).component);
+        for (let idx = 0; idx < sortedVersions.length; idx++) {
+            const cur = utils.getComponentVersion(newVersion.name);
+            const sor = utils.getComponentVersion(sortedVersions[idx].name);
+            if (new version_it_1.SemVer(sor.version).isGreaterThan(new version_it_1.SemVer(cur.version))) {
+                await this.moveVersion(newVersion, idx > 0 ? sortedVersions[idx - 1] : "First");
+                return;
+            }
+            else if (idx === sortedVersions.length - 1) {
+                await this.moveVersion(newVersion, sortedVersions[idx]);
+                return;
+            }
+        }
     }
     /**
      * Updates the version of an issue.
@@ -28670,8 +29266,146 @@ class JiraClient {
             }
         });
     }
+    /**
+     * Moves a version to a new position.
+     * @param version - The version to move.
+     * @param after - The version to move after.
+     */
+    async moveVersion(version, after) {
+        if (after === "First") {
+            console.log(`ℹ️  Version ${version.name} is moved to the first position.`);
+            await this.request("POST", `version/${version.id}/move`, { position: "First" });
+            return;
+        }
+        core.info(`ℹ️  Moving version ${version.name} after version ${after.name}...`);
+        await this.request("POST", `version/${version.id}/move`, { after: after.self });
+    }
+    /**
+     * Sorts the versions of a project.
+     * @param project The key or ID of the project.
+     * @returns A promise that resolves when the versions are sorted.
+     */
+    async sortVersions(project) {
+        const projectData = await this.getProject(project);
+        core.startGroup(`📦 Sorting versions in project ${project}...`);
+        if (projectData.versions.length === 0) {
+            core.info(`ℹ️  No versions found in project ${project}.`);
+            return;
+        }
+        const sortedVersions = utils.sortFixVersions(projectData.versions);
+        await this.moveVersion(sortedVersions[0], "First");
+        for (let idx = 1; idx < sortedVersions.length; idx++) {
+            await this.moveVersion(sortedVersions[idx], sortedVersions[idx - 1]);
+        }
+        core.endGroup();
+    }
 }
 exports.JiraClient = JiraClient;
+
+
+/***/ }),
+
+/***/ 1314:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+/*
+ * SPDX-FileCopyrightText: 2024 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.sortFixVersions = exports.setComponentVersion = exports.getComponentVersion = exports.isSemver = exports.isValidComponent = void 0;
+const version_it_1 = __nccwpck_require__(4209);
+/**
+ * Check if the component is valid, incl.
+ * - No spaces
+ * - All lower case
+ *
+ * @param component - The component to check
+ * @returns - True if the component is valid, false otherwise
+ */
+function isValidComponent(component) {
+    if (!component) {
+        return true;
+    }
+    return !component.includes(" ") && component === component.toLowerCase();
+}
+exports.isValidComponent = isValidComponent;
+/**
+ * Check if the version is valid SemVer.
+ * @param version - The version to check
+ * @returns - True if the version is valid, false otherwise
+ */
+function isSemver(version) {
+    try {
+        new version_it_1.SemVer(version);
+    }
+    catch (error) {
+        return false;
+    }
+    return true;
+}
+exports.isSemver = isSemver;
+/**
+ * Extracts the component name and version from the provided version name.
+ * @param version - The version name
+ * @returns - The component name and version
+ */
+function getComponentVersion(version) {
+    const index = version.lastIndexOf("/");
+    if (index === -1) {
+        return { component: undefined, version };
+    }
+    const component = version.substring(0, index);
+    const versionStr = version.substring(index + 1);
+    if (!isValidComponent(component)) {
+        throw new Error(`Invalid component: ${component}`);
+    }
+    if (!isSemver(versionStr)) {
+        throw new Error(`Invalid Semantic Version: ${versionStr}`);
+    }
+    return { component, version: versionStr };
+}
+exports.getComponentVersion = getComponentVersion;
+/**
+ * Creates a component version name from the provided component and version.
+ * @param component - The component name
+ * @param version - The version
+ * @returns - The component version name
+ * @throws - If the component or version is invalid
+ */
+function setComponentVersion(version, component) {
+    if (!isValidComponent(component)) {
+        throw new Error(`Invalid component: ${component}`);
+    }
+    if (!isSemver(version)) {
+        throw new Error(`Invalid Semantic Version: ${version}`);
+    }
+    if (!component) {
+        return version;
+    }
+    return `${component}/${version}`;
+}
+exports.setComponentVersion = setComponentVersion;
+/**
+ * Sorts the provided versions by component and version.
+ * @param versions - The versions to sort
+ * @returns - The sorted versions
+ */
+function sortFixVersions(versions) {
+    return [...versions]
+        .filter(v => {
+        return isSemver(getComponentVersion(v.name).version);
+    })
+        .sort((a, b) => {
+        return new version_it_1.SemVer(getComponentVersion(a.name).version).compareTo(new version_it_1.SemVer(getComponentVersion(b.name).version));
+    })
+        .sort((a, b) => {
+        return (getComponentVersion(b.name).component ?? "").localeCompare(getComponentVersion(a.name).component ?? "");
+    });
+}
+exports.sortFixVersions = sortFixVersions;
 
 
 /***/ }),

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1831,6 +1831,579 @@ function isLoopbackAddress(host) {
 
 /***/ }),
 
+/***/ 1842:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+/*
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+SPDX-License-Identifier: MIT
+*/
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.formatFromString = exports.CalVer = void 0;
+const utils_1 = __nccwpck_require__(3464);
+/**
+ * A simple CalVer implementation
+ * @class CalVer
+ * @member major Major version
+ * @member minor Minor version
+ * @member micro Micro version
+ * @member modifier Modifier
+ * @method toString Returns the CalVer as a string
+ * @method increment Increments the CalVer by the provided type
+ */
+class CalVer {
+    constructor(format, version, prefix) {
+        var _a, _b, _c, _d, _e, _f;
+        this.format = typeof format === "string" ? formatFromString(format) : format;
+        if (typeof version === "string") {
+            if (prefix !== undefined) {
+                if (!version.startsWith(prefix))
+                    throw new Error("Incorrect CalVer, missing prefix");
+                version = version.substring(prefix.length);
+            }
+            const groups = (_a = this.format.regex.exec(version)) === null || _a === void 0 ? void 0 : _a.groups;
+            if (groups === undefined) {
+                throw new Error("Could not parse CalVer");
+            }
+            this.prefix = prefix;
+            this.major = parseInt(groups.major);
+            this.minor = parseInt(groups.minor);
+            this.micro = parseInt(groups.micro);
+            this.modifier = groups.modifier;
+        }
+        else {
+            this.prefix = (_b = version === null || version === void 0 ? void 0 : version.prefix) !== null && _b !== void 0 ? _b : prefix;
+            this.major = (_c = version === null || version === void 0 ? void 0 : version.major) !== null && _c !== void 0 ? _c : 0;
+            this.minor = (_d = version === null || version === void 0 ? void 0 : version.minor) !== null && _d !== void 0 ? _d : 0;
+            this.micro = (_e = version === null || version === void 0 ? void 0 : version.micro) !== null && _e !== void 0 ? _e : (this.format.micro ? 0 : undefined);
+            this.modifier = (_f = version === null || version === void 0 ? void 0 : version.modifier) !== null && _f !== void 0 ? _f : undefined;
+        }
+    }
+    /**
+     * Increments the modifier (in format "key.value") by 1.
+     * If no modifier is available, it will return "build.1"
+     * @returns Incremented modifier
+     */
+    incrementModifier() {
+        if (this.modifier === undefined)
+            return "build.1";
+        const keyValue = (0, utils_1.getKeyValuePair)(this.modifier);
+        if (keyValue === undefined)
+            throw new Error("Cannot increment modifiers without a key/value pair");
+        return `${keyValue.key}.${keyValue.value + 1}`;
+    }
+    /**
+     * Updates versions associated with calendar items (i.e. YYYY, MM, WW, DD)
+     * in the provided CalVer format.
+     * @param format The CalVer format
+     * @returns The updated version based on the current date.
+     */
+    updateCalendar(format) {
+        if (format === undefined || ["MAJOR", "MINOR", "MICRO"].includes(format))
+            return;
+        if (format.includes("Y"))
+            return new Date().getFullYear();
+        if (format.includes("M"))
+            return new Date().getMonth() + 1;
+        if (format.includes("W"))
+            return (0, utils_1.getISO8601WeekNumber)();
+        if (format.includes("D"))
+            return new Date().getDate() + 1;
+        return;
+    }
+    /**
+     * Returns a string, where the value is formatted correctly based on the provided format.
+     * @param value Value to format
+     * @param format CalVer format to use
+     * @returns Formatted value
+     */
+    formatVersionCore(value, format) {
+        if (["MAJOR", "MINOR", "MICRO"].includes(format))
+            return value.toString();
+        if (format === "YYYY")
+            return value.toString().padStart(4, "0");
+        if (format === "0Y")
+            return value
+                .toString()
+                .substring(value.toString().length - 3)
+                .padStart(3, "0");
+        if (format.includes("0"))
+            return value
+                .toString()
+                .substring(value.toString().length - 2)
+                .padStart(2, "0");
+        return value.toString().substring(value.toString().length - 2);
+    }
+    /**
+     * Returns the CalVer as a string
+     * @returns CalVer as a string
+     */
+    toString() {
+        var _a;
+        let version = (_a = this.prefix) !== null && _a !== void 0 ? _a : "";
+        version += `${this.formatVersionCore(this.major, this.format.major)}.${this.formatVersionCore(this.minor, this.format.minor)}`;
+        if (this.micro !== undefined && this.format.micro !== undefined)
+            version += `.${this.formatVersionCore(this.micro, this.format.micro)}`;
+        if (this.modifier !== undefined)
+            version += `-${this.modifier}`;
+        return version;
+    }
+    /**
+     * Increments the CalVer by the provided type;
+     *   - "calendar": Increments the calendar (i.e. YYYY, MM, WW, DD)
+     *   - "major": Increments the major version
+     *   - "minor": Increments the minor version
+     *   - "micro": Increments the micro version
+     *   - "modifier": Increments the modifier
+     * @param type Type of increment
+     * @returns Incremented CalVer
+     */
+    increment(type) {
+        var _a, _b, _c, _d;
+        switch (type) {
+            case "CALENDAR": {
+                // Increment the calendar only, this allows us to validate whether the calendar has changed
+                const newVersion = new CalVer(this.format, {
+                    prefix: this.prefix,
+                    major: (_a = this.updateCalendar(this.format.major)) !== null && _a !== void 0 ? _a : this.major,
+                    minor: (_b = this.updateCalendar(this.format.minor)) !== null && _b !== void 0 ? _b : this.minor,
+                    micro: (_c = this.updateCalendar(this.format.micro)) !== null && _c !== void 0 ? _c : this.micro,
+                    modifier: this.modifier,
+                });
+                // Increment the modifier if the calendar has not changed
+                if (newVersion.isEqualTo(this))
+                    return new CalVer(this.format, { ...this, modifier: this.incrementModifier() });
+                // If the calendar items are updated, reset MAJOR, MINOR, MICRO...
+                for (const subtype of ["major", "minor", "micro"]) {
+                    const filter = Object.keys(this.format).filter(key => this.format[key] === subtype.toUpperCase());
+                    if (filter.length !== 1)
+                        continue;
+                    newVersion[filter[0].toLowerCase()] = 0;
+                }
+                // ... and MODIFIER
+                newVersion.modifier = undefined;
+                return newVersion;
+            }
+            case "MAJOR":
+            case "MINOR":
+            case "MICRO": {
+                const filter = Object.keys(this.format).filter(key => this.format[key] === type.toUpperCase());
+                if (filter.length !== 1)
+                    throw new Error(`Unable to increment ${type} version as it is not part of the format`);
+                const item = filter[0].toLowerCase();
+                if (item === "major")
+                    return new CalVer(this.format, { major: this.major + 1, modifier: undefined });
+                if (item === "minor")
+                    return new CalVer(this.format, { major: this.major, minor: this.minor + 1, modifier: undefined });
+                if (item === "micro")
+                    return new CalVer(this.format, {
+                        major: this.major,
+                        minor: this.minor,
+                        micro: ((_d = this.micro) !== null && _d !== void 0 ? _d : 0) + 1,
+                        modifier: undefined,
+                    });
+                throw new Error("Unknown increment type.");
+            }
+            case "MODIFIER":
+                return new CalVer(this.format, { ...this, modifier: this.incrementModifier() });
+        }
+    }
+    /**
+     * Confirms that the provided format is identical to the current format
+     * @param other Other format to compare against
+     * @returns True if the formats are identical, false otherwise
+     */
+    isFormatIdentical(other) {
+        return this.format.major === other.major && this.format.minor === other.minor && this.format.micro === other.micro;
+    }
+    isEqualTo(other) {
+        return this.compareTo(other) === 0;
+    }
+    isGreaterThan(other) {
+        return this.compareTo(other) === 1;
+    }
+    isLessThan(other) {
+        return this.compareTo(other) === -1;
+    }
+    /**
+     * Returns 0 when current version is equal to the provided version,
+     * 1 when current version is greater than the provided version,
+     * and -1 when current version is less than the provided version.
+     *
+     * Resulting in the following ordering (taking `YYYY.0M.MICRO` as an example):
+     *
+     * 2022.03.1
+     * 2022.03.2
+     * 2022.11.1
+     * 2022.11.1-alpha.1
+     * 2022.11.1-alpha.2
+     * 2022.11.1-beta.1
+     * 2022.11.2
+     * 2023.01.1
+     *
+     * @param other CalVer to compare to
+     * @returns
+     */
+    compareTo(other) {
+        if (!this.isFormatIdentical(other.format))
+            throw new Error("Unable to compare CalVer with different formats");
+        if (this.major > other.major)
+            return 1;
+        if (this.major < other.major)
+            return -1;
+        if (this.minor > other.minor)
+            return 1;
+        if (this.minor < other.minor)
+            return -1;
+        if (this.micro !== undefined && other.micro !== undefined) {
+            if (this.micro > other.micro)
+                return 1;
+            if (this.micro < other.micro)
+                return -1;
+        }
+        if (this.modifier !== undefined && other.modifier === undefined)
+            return 1;
+        if (this.modifier === undefined && other.modifier !== undefined)
+            return -1;
+        if (this.modifier !== undefined && other.modifier !== undefined) {
+            const aModifier = (0, utils_1.getKeyValuePair)(this.modifier);
+            const bModifier = (0, utils_1.getKeyValuePair)(other.modifier);
+            if (aModifier !== undefined && bModifier !== undefined) {
+                if (aModifier.key !== bModifier.key)
+                    return aModifier.key.localeCompare(bModifier.key);
+                if (aModifier.value > bModifier.value)
+                    return 1;
+                if (aModifier.value < bModifier.value)
+                    return -1;
+            }
+            else {
+                return this.modifier.localeCompare(other.modifier);
+            }
+        }
+        return 0;
+    }
+}
+exports.CalVer = CalVer;
+/**
+ * Generates a regex based on the provided CalVer format
+ * @param format The CalVer format
+ * @returns The regex
+ * @internal
+ */
+function formatFromString(format) {
+    var _a;
+    const elements = (_a = /^(?<major>[A-Z0]+)\.(?<minor>[A-Z0]+)(\.(?<micro>[A-Z0]+))?$/.exec(format)) === null || _a === void 0 ? void 0 : _a.groups;
+    if (elements === undefined)
+        throw new Error(`Invalid CalVer format: ${format}`);
+    const usedElements = [];
+    const versions = [];
+    for (const key of Object.keys(elements)) {
+        if (elements[key] === undefined)
+            continue;
+        if (usedElements.includes(elements[key])) {
+            throw new Error(`Duplicate CalVer format element: ${elements[key]}`);
+        }
+        if (["MAJOR", "MINOR", "MICRO"].includes(elements[key]))
+            versions.push(`(?<${key}>\\d+)`);
+        else if (elements[key] === "YYYY")
+            versions.push(`(?<${key}>\\d{4})`);
+        else if (elements[key] === "YY")
+            versions.push(`(?<${key}>\\d{1,3})`);
+        else if (elements[key] === "0Y")
+            versions.push(`(?<${key}>\\d{3})`);
+        else if (["0M", "0W", "0D"].includes(elements[key]))
+            versions.push(`(?<${key}>\\d{2})`);
+        else if (["MM", "WW", "DD"].includes(elements[key]))
+            versions.push(`(?<${key}>\\d{1,2})`);
+        else
+            throw new Error(`Unknown CalVer format element: ${elements}, ${key}, ${elements[key]}`);
+        usedElements.push(elements[key]);
+    }
+    return {
+        regex: new RegExp(`^${versions.join(".")}(-(?<modifier>[\\w._]+))?$`),
+        major: elements.major,
+        minor: elements.minor,
+        micro: elements.micro,
+    };
+}
+exports.formatFromString = formatFromString;
+
+
+/***/ }),
+
+/***/ 4209:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+/*
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+SPDX-License-Identifier: MIT
+*/
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.CalVer = exports.SemVer = void 0;
+var semver_1 = __nccwpck_require__(292);
+Object.defineProperty(exports, "SemVer", ({ enumerable: true, get: function () { return semver_1.SemVer; } }));
+var calver_1 = __nccwpck_require__(1842);
+Object.defineProperty(exports, "CalVer", ({ enumerable: true, get: function () { return calver_1.CalVer; } }));
+
+
+/***/ }),
+
+/***/ 292:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+/*
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+SPDX-License-Identifier: MIT
+*/
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.SemVer = void 0;
+const assert_1 = __importDefault(__nccwpck_require__(9491));
+const utils_1 = __nccwpck_require__(3464);
+const SEMVER_REGEX = /^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<preRelease>[a-zA-Z0-9.-]+))?(\+(?<build>[a-zA-Z0-9.-]+))?$/;
+/**
+ * A simple SemVer implementation
+ * @class SemVer
+ * @implements ISemVer
+ * @member major Major version
+ * @member minor Minor version
+ * @member patch Patch version
+ * @member preRelease Pre-release identifier
+ * @member build Build identifier
+ * @method toString Returns the SemVer as a string
+ */
+class SemVer {
+    constructor(version, prefix) {
+        var _a, _b, _c, _d, _e;
+        if (typeof version === "string") {
+            // Handle prefix
+            if (prefix !== undefined) {
+                if (!version.startsWith(prefix))
+                    throw new Error("Incorrect SemVer, missing prefix");
+                version = version.substring(prefix.length);
+            }
+            // SemVer regex
+            const groups = (_a = SEMVER_REGEX.exec(version)) === null || _a === void 0 ? void 0 : _a.groups;
+            if (groups === undefined)
+                throw new Error("Could not parse SemVer");
+            this.prefix = prefix;
+            this.major = parseInt(groups.major);
+            this.minor = parseInt(groups.minor);
+            this.patch = parseInt(groups.patch);
+            this.preRelease = groups.preRelease;
+            this.build = groups.build;
+        }
+        else {
+            this.prefix = (_b = version === null || version === void 0 ? void 0 : version.prefix) !== null && _b !== void 0 ? _b : prefix;
+            this.major = (_c = version === null || version === void 0 ? void 0 : version.major) !== null && _c !== void 0 ? _c : 0;
+            this.minor = (_d = version === null || version === void 0 ? void 0 : version.minor) !== null && _d !== void 0 ? _d : 0;
+            this.patch = (_e = version === null || version === void 0 ? void 0 : version.patch) !== null && _e !== void 0 ? _e : 0;
+            this.preRelease = version === null || version === void 0 ? void 0 : version.preRelease;
+            this.build = version === null || version === void 0 ? void 0 : version.build;
+        }
+    }
+    /**
+     * Increments the value of the SemVer identifier
+     * @param identifier Identifier to increment
+     * @returns Incremented identifier, undefined when identifier does not exist
+     */
+    incrementIdentifier(identifier) {
+        if (this[identifier] === undefined)
+            return;
+        const keyValuePair = (0, utils_1.getKeyValuePair)(this[identifier]);
+        if ((keyValuePair === null || keyValuePair === void 0 ? void 0 : keyValuePair.key) === undefined || (keyValuePair === null || keyValuePair === void 0 ? void 0 : keyValuePair.value) === undefined)
+            throw new Error(`Unable to bump ${identifier}`);
+        return `${keyValuePair.key}.${keyValuePair.value + 1}`;
+    }
+    /**
+     * Increments the SemVer based on the provided type:
+     * - major: 1.0.0 => 2.0.0
+     * - minor: 1.0.0 => 1.1.0
+     * - patch: 1.0.0 => 1.0.1
+     * - preRelease: 1.0.0 => 1.0.0-rc.1
+     * - build: 1.0.0 => 1.0.0+build.1
+     *
+     * Incrementing a type will reset any lesser significant types (e.g. incrementing minor will reset patch, preRelease, and build).
+     *   order of significance: major > minor > patch > preRelease > build
+     *
+     * @param type Type of increment
+     * @returns Incremented SemVer
+     */
+    increment(type) {
+        var _a, _b;
+        switch (type) {
+            case "PRERELEASE":
+                return new SemVer({ ...this, preRelease: (_a = this.incrementIdentifier("preRelease")) !== null && _a !== void 0 ? _a : "rc.1", build: undefined });
+            case "BUILD":
+                return new SemVer({
+                    ...this,
+                    preRelease: this.preRelease,
+                    build: (_b = this.incrementIdentifier("build")) !== null && _b !== void 0 ? _b : "build.1",
+                });
+            case "MAJOR":
+                return new SemVer({ prefix: this.prefix, major: this.major + 1 });
+            case "MINOR":
+                return new SemVer({ prefix: this.prefix, major: this.major, minor: this.minor + 1 });
+            case "PATCH":
+                return new SemVer({ prefix: this.prefix, major: this.major, minor: this.minor, patch: this.patch + 1 });
+        }
+    }
+    compareIdentifier(a, b) {
+        if (a === b)
+            return 0;
+        if (!a)
+            return -1;
+        if (!b)
+            return 1;
+        const aId = (0, utils_1.getKeyValuePair)(a);
+        const bId = (0, utils_1.getKeyValuePair)(b);
+        if (!aId)
+            return bId ? -1 : a.localeCompare(b);
+        if (!bId)
+            return 1;
+        if (aId.key !== bId.key)
+            return a.localeCompare(b);
+        if (aId.value !== bId.value) {
+            (0, assert_1.default)(aId.value !== undefined && bId.value !== undefined);
+            return aId.value > bId.value ? 1 : -1;
+        }
+        return 0;
+    }
+    /**
+     * Returns 0 when current version is equal to the provided version,
+     * 1 when current version is greater than the provided version,
+     * and -1 when current version is less than the provided version.
+     *
+     * Resulting in the following ordering:
+     *
+     * 0.0.1
+     * 0.0.2
+     * 0.1.0
+     * 0.2.0-rc.1
+     * 0.2.0-rc.2
+     * 0.2.0
+     * 0.2.0+build.1
+     * 0.2.0+build.2
+     * 0.2.1-rc.1+build.1
+     * 0.2.1-rc.1+build.2
+     * 0.2.1-rc.2
+     * 1.0.0
+     *
+     * @param other SemVer to compare to
+     * @returns
+     */
+    compareTo(other) {
+        const keys = ["major", "minor", "patch"];
+        for (const key of keys) {
+            if (this[key] !== other[key]) {
+                return this[key] > other[key] ? 1 : -1;
+            }
+        }
+        // undefined, prerelease, build, prerelease + build
+        // prerelease
+        // build
+        // prerelease + build
+        const mapping = [
+            [0, 1, -1, 1],
+            [
+                -1,
+                this.compareIdentifier(this.preRelease, other.preRelease),
+                -1,
+                this.compareIdentifier(this.preRelease, other.preRelease) === 0
+                    ? this.compareIdentifier(this.build, other.build)
+                    : this.compareIdentifier(this.preRelease, other.preRelease),
+            ],
+            [1, 1, this.compareIdentifier(this.build, other.build), 1],
+            [
+                -1,
+                this.compareIdentifier(this.preRelease, other.preRelease) === 0
+                    ? 1
+                    : this.compareIdentifier(this.preRelease, other.preRelease),
+                -1,
+                this.compareIdentifier(this.preRelease, other.preRelease) === 0
+                    ? this.compareIdentifier(this.build, other.build)
+                    : this.compareIdentifier(this.preRelease, other.preRelease),
+            ],
+        ];
+        const getIndex = (item) => !item.preRelease && !item.build ? 0 : item.preRelease && !item.build ? 1 : !item.preRelease && item.build ? 2 : 3;
+        return mapping[getIndex(this)][getIndex(other)];
+    }
+    isEqualTo(other) {
+        return this.compareTo(other) === 0;
+    }
+    isGreaterThan(other) {
+        return this.compareTo(other) === 1;
+    }
+    isLessThan(other) {
+        return this.compareTo(other) === -1;
+    }
+    /**
+     * Returns the SemVer as a string
+     * @returns SemVer as a string
+     */
+    toString() {
+        return `${this.prefix !== undefined ? this.prefix : ""}${this.major}.${this.minor}.${this.patch}${this.preRelease ? "-" + this.preRelease : ""}${this.build ? "+" + this.build : ""}`;
+    }
+}
+exports.SemVer = SemVer;
+
+
+/***/ }),
+
+/***/ 3464:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+/*
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+SPDX-License-Identifier: MIT
+*/
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getISO8601WeekNumber = exports.getKeyValuePair = void 0;
+/**
+ * Returns a key-value pair from the provided identifier (e.g. alpha.1 => { key: "alpha.", value: 1 })
+ * @param identifier Identifier to parse (e.g. alpha.1)
+ * @returns Identifier value (e.g. 1)
+ * @internal
+ */
+function getKeyValuePair(value) {
+    const kvpRegex = /^([a-zA-Z-]+)[.]([0-9]+)$/;
+    const match = kvpRegex.exec(value !== null && value !== void 0 ? value : "");
+    if (match === null)
+        return;
+    return { key: match[1], value: parseInt(match[2]) };
+}
+exports.getKeyValuePair = getKeyValuePair;
+/**
+ * Returns the week number of the current date (ISO 8601)
+ * @returns The week number of the current date
+ * @internal
+ */
+function getISO8601WeekNumber() {
+    const date = new Date();
+    const dayNumber = (date.getDay() + 6) % 7;
+    date.setDate(date.getDate() - dayNumber + 3);
+    const firstThursday = date.valueOf();
+    date.setMonth(0, 1);
+    if (date.getDay() !== 4) {
+        date.setMonth(0, 1 + ((4 - date.getDay() + 7) % 7));
+    }
+    return 1 + Math.ceil((firstThursday - date.valueOf()) / 604800000);
+}
+exports.getISO8601WeekNumber = getISO8601WeekNumber;
+
+
+/***/ }),
+
 /***/ 4812:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
@@ -28416,6 +28989,123 @@ exports["default"] = _default;
 
 /***/ }),
 
+/***/ 1836:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+/*
+ * SPDX-FileCopyrightText: 2024 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const commander_1 = __nccwpck_require__(4379);
+const jira_1 = __nccwpck_require__(2222);
+const utils = __importStar(__nccwpck_require__(1314));
+const program = new commander_1.Command();
+/**
+ * Main entry point for the CLI tool.
+ */
+program
+    .name("jira-version-me")
+    .description("Jira Release Management")
+    .requiredOption("-p, --project <project>", "The Jira project key")
+    .requiredOption("-t, --token <token>", "The Jira API token")
+    .requiredOption("-u, --url <url>", "The Jira URL");
+/**
+ * Validate command
+ */
+program
+    .command("update")
+    .option("-c, --component <component>", "The component to update")
+    .requiredOption("-v, --version <version>", "The version to create")
+    .option("-d, --description <description>", "The description of the version")
+    .option("-r, --release", "Mark the version as released")
+    .action(async (options) => {
+    console.log("📔 JiraVersionMe - Update Jira Release");
+    console.log("--------------------------------------");
+    options = { ...program.opts(), ...options };
+    const jira = new jira_1.JiraClient(options.url, options.token);
+    const componentVersion = utils.setComponentVersion(options.version, options.component);
+    try {
+        await jira.createOrUpdateVersion(options.project, {
+            name: componentVersion,
+            description: options.description,
+            archived: false,
+            released: options.release ?? false,
+            releaseDate: options.release ? new Date().toISOString() : undefined,
+        });
+    }
+    catch (error) {
+        program.error(`❌ ${error.message}`);
+        return;
+    }
+    console.log(`✅ Version ${componentVersion} is up-to-date!`);
+});
+program
+    .command("assign")
+    .option("-c, --component <component>", "The component to update")
+    .requiredOption("-v, --version <version>", "The version to assign tickets to")
+    .requiredOption("-t, --ticket <ticket...>", "List of JIRA tickets to assign to the specified version")
+    .action(async (options) => {
+    console.log("📔 JiraVersionMe - Assign Jira Tickets to Release");
+    console.log("-------------------------------------------------");
+    options = { ...program.opts(), ...options };
+    const jira = new jira_1.JiraClient(options.url, options.token);
+    const componentVersion = utils.setComponentVersion(options.version, options.component);
+    for (const issue of options.ticket) {
+        try {
+            await jira.assignTicketToVersion(issue, componentVersion);
+        }
+        catch (error) {
+            program.error(`❌ ${error.message}`);
+            return;
+        }
+        console.log(`✅ Issue ${issue} assigned to version ${componentVersion} successfully!`);
+    }
+});
+program.command("sort").action(async (options) => {
+    console.log("📔 JiraVersionMe - Sort Jira Versions");
+    console.log("------------------------------------");
+    options = { ...program.opts(), ...options };
+    const jira = new jira_1.JiraClient(options.url, options.token);
+    try {
+        await jira.sortVersions(options.project);
+    }
+    catch (error) {
+        program.error(`❌ ${error.message}`);
+        return;
+    }
+    console.log(`✅ Versions sorted successfully!`);
+});
+program.parse(process.argv);
+
+
+/***/ }),
+
 /***/ 2222:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -28455,7 +29145,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.JiraClient = void 0;
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const core = __importStar(__nccwpck_require__(2186));
+const version_it_1 = __nccwpck_require__(4209);
 const axios_1 = __importDefault(__nccwpck_require__(8757));
+const utils = __importStar(__nccwpck_require__(1314));
 /**
  * Represents a Jira client for making API requests.
  */
@@ -28528,9 +29220,13 @@ class JiraClient {
      * @returns - A promise that resolves to the project information.
      */
     async getProject(project) {
-        return (await this.request("GET", `project/${project}`).catch(err => {
+        const projectData = (await this.request("GET", `project/${project}`).catch(err => {
             throw new Error(err.response.data.errorMessages.join(", "));
         })).data;
+        if (typeof projectData === "string") {
+            throw new Error(`Unable to retrieve the Jira project ${project}.`);
+        }
+        return projectData;
     }
     /**
      * Creates or updates a version in a project.
@@ -28540,9 +29236,6 @@ class JiraClient {
      */
     async createOrUpdateVersion(project, version) {
         const projectData = await this.getProject(project);
-        if (typeof projectData === "string") {
-            throw new Error(`Unable to retrieve the Jira project ${project}.`);
-        }
         for (const v of projectData.versions || []) {
             if (version.name === v.name) {
                 core.info(`ℹ️  Version ${version.name} already exists in project ${project}, updating....`);
@@ -28553,13 +29246,28 @@ class JiraClient {
             }
         }
         core.info(`ℹ️  Creating version ${version.name} in project ${project}...`);
-        await this.request("POST", "version", {
+        const newVersion = (await this.request("POST", "version", {
             ...version,
             project: project,
             projectId: projectData.id,
         }).catch(err => {
             throw new Error(err.response.data.errorMessages.join(", "));
-        });
+        })).data;
+        const sortedVersions = utils
+            .sortFixVersions(projectData.versions)
+            .filter(v => utils.getComponentVersion(v.name).component === utils.getComponentVersion(newVersion.name).component);
+        for (let idx = 0; idx < sortedVersions.length; idx++) {
+            const cur = utils.getComponentVersion(newVersion.name);
+            const sor = utils.getComponentVersion(sortedVersions[idx].name);
+            if (new version_it_1.SemVer(sor.version).isGreaterThan(new version_it_1.SemVer(cur.version))) {
+                await this.moveVersion(newVersion, idx > 0 ? sortedVersions[idx - 1] : "First");
+                return;
+            }
+            else if (idx === sortedVersions.length - 1) {
+                await this.moveVersion(newVersion, sortedVersions[idx]);
+                return;
+            }
+        }
     }
     /**
      * Updates the version of an issue.
@@ -28577,8 +29285,146 @@ class JiraClient {
             }
         });
     }
+    /**
+     * Moves a version to a new position.
+     * @param version - The version to move.
+     * @param after - The version to move after.
+     */
+    async moveVersion(version, after) {
+        if (after === "First") {
+            console.log(`ℹ️  Version ${version.name} is moved to the first position.`);
+            await this.request("POST", `version/${version.id}/move`, { position: "First" });
+            return;
+        }
+        core.info(`ℹ️  Moving version ${version.name} after version ${after.name}...`);
+        await this.request("POST", `version/${version.id}/move`, { after: after.self });
+    }
+    /**
+     * Sorts the versions of a project.
+     * @param project The key or ID of the project.
+     * @returns A promise that resolves when the versions are sorted.
+     */
+    async sortVersions(project) {
+        const projectData = await this.getProject(project);
+        core.startGroup(`📦 Sorting versions in project ${project}...`);
+        if (projectData.versions.length === 0) {
+            core.info(`ℹ️  No versions found in project ${project}.`);
+            return;
+        }
+        const sortedVersions = utils.sortFixVersions(projectData.versions);
+        await this.moveVersion(sortedVersions[0], "First");
+        for (let idx = 1; idx < sortedVersions.length; idx++) {
+            await this.moveVersion(sortedVersions[idx], sortedVersions[idx - 1]);
+        }
+        core.endGroup();
+    }
 }
 exports.JiraClient = JiraClient;
+
+
+/***/ }),
+
+/***/ 1314:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+/*
+ * SPDX-FileCopyrightText: 2024 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.sortFixVersions = exports.setComponentVersion = exports.getComponentVersion = exports.isSemver = exports.isValidComponent = void 0;
+const version_it_1 = __nccwpck_require__(4209);
+/**
+ * Check if the component is valid, incl.
+ * - No spaces
+ * - All lower case
+ *
+ * @param component - The component to check
+ * @returns - True if the component is valid, false otherwise
+ */
+function isValidComponent(component) {
+    if (!component) {
+        return true;
+    }
+    return !component.includes(" ") && component === component.toLowerCase();
+}
+exports.isValidComponent = isValidComponent;
+/**
+ * Check if the version is valid SemVer.
+ * @param version - The version to check
+ * @returns - True if the version is valid, false otherwise
+ */
+function isSemver(version) {
+    try {
+        new version_it_1.SemVer(version);
+    }
+    catch (error) {
+        return false;
+    }
+    return true;
+}
+exports.isSemver = isSemver;
+/**
+ * Extracts the component name and version from the provided version name.
+ * @param version - The version name
+ * @returns - The component name and version
+ */
+function getComponentVersion(version) {
+    const index = version.lastIndexOf("/");
+    if (index === -1) {
+        return { component: undefined, version };
+    }
+    const component = version.substring(0, index);
+    const versionStr = version.substring(index + 1);
+    if (!isValidComponent(component)) {
+        throw new Error(`Invalid component: ${component}`);
+    }
+    if (!isSemver(versionStr)) {
+        throw new Error(`Invalid Semantic Version: ${versionStr}`);
+    }
+    return { component, version: versionStr };
+}
+exports.getComponentVersion = getComponentVersion;
+/**
+ * Creates a component version name from the provided component and version.
+ * @param component - The component name
+ * @param version - The version
+ * @returns - The component version name
+ * @throws - If the component or version is invalid
+ */
+function setComponentVersion(version, component) {
+    if (!isValidComponent(component)) {
+        throw new Error(`Invalid component: ${component}`);
+    }
+    if (!isSemver(version)) {
+        throw new Error(`Invalid Semantic Version: ${version}`);
+    }
+    if (!component) {
+        return version;
+    }
+    return `${component}/${version}`;
+}
+exports.setComponentVersion = setComponentVersion;
+/**
+ * Sorts the provided versions by component and version.
+ * @param versions - The versions to sort
+ * @returns - The sorted versions
+ */
+function sortFixVersions(versions) {
+    return [...versions]
+        .filter(v => {
+        return isSemver(getComponentVersion(v.name).version);
+    })
+        .sort((a, b) => {
+        return new version_it_1.SemVer(getComponentVersion(a.name).version).compareTo(new version_it_1.SemVer(getComponentVersion(b.name).version));
+    })
+        .sort((a, b) => {
+        return (getComponentVersion(b.name).component ?? "").localeCompare(getComponentVersion(a.name).component ?? "");
+    });
+}
+exports.sortFixVersions = sortFixVersions;
 
 
 /***/ }),
@@ -38308,81 +39154,12 @@ module.exports = JSON.parse('{"application/1d-interleaved-parityfec":{"source":"
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
-var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be in strict mode.
-(() => {
-"use strict";
-var exports = __webpack_exports__;
-
-/*
- * SPDX-FileCopyrightText: 2024 Kevin de Jong <monkaii@hotmail.com>
- * SPDX-License-Identifier: MIT
- */
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-const commander_1 = __nccwpck_require__(4379);
-const jira_1 = __nccwpck_require__(2222);
-const program = new commander_1.Command();
-/**
- * Main entry point for the CLI tool.
- */
-program
-    .name("jira-version-me")
-    .description("Jira Release Management")
-    .requiredOption("-p, --project <project>", "The Jira project key")
-    .requiredOption("-t, --token <token>", "The Jira API token")
-    .requiredOption("-u, --url <url>", "The Jira URL");
-/**
- * Validate command
- */
-program
-    .command("update")
-    .requiredOption("-v, --version <version>", "The version to create")
-    .option("-d, --description <description>", "The description of the version")
-    .option("-r, --release", "Mark the version as released")
-    .action(async (options) => {
-    console.log("📔 JiraVersionMe - Update Jira Release");
-    console.log("--------------------------------------");
-    options = { ...program.opts(), ...options };
-    const jira = new jira_1.JiraClient(options.url, options.token);
-    try {
-        await jira.createOrUpdateVersion(options.project, {
-            name: options.version,
-            description: options.description,
-            archived: false,
-            released: options.release ?? false,
-            releaseDate: options.release ? new Date().toISOString() : undefined,
-        });
-    }
-    catch (error) {
-        program.error(`❌ ${error.message}`);
-        return;
-    }
-    console.log(`✅ Version ${options.version} is up-to-date!`);
-});
-program
-    .command("assign")
-    .requiredOption("-v, --version <version>", "The version to assign tickets to")
-    .requiredOption("-t, --ticket <ticket...>", "List of JIRA tickets to assign to the specified version")
-    .action(async (options) => {
-    console.log("📔 JiraVersionMe - Assign Jira Tickets to Release");
-    console.log("-------------------------------------------------");
-    options = { ...program.opts(), ...options };
-    const jira = new jira_1.JiraClient(options.url, options.token);
-    for (const issue of options.ticket) {
-        try {
-            await jira.assignTicketToVersion(issue, options.version);
-        }
-        catch (error) {
-            program.error(`❌ ${error.message}`);
-            return;
-        }
-        console.log(`✅ Issue ${issue} assigned to version ${options.version} successfully!`);
-    }
-});
-program.parse(process.argv);
-
-})();
-
-module.exports = __webpack_exports__;
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __nccwpck_require__(1836);
+/******/ 	module.exports = __webpack_exports__;
+/******/ 	
 /******/ })()
 ;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1",
+        "@dev-build-deploy/version-it": "^0.3.0",
         "axios": "^1.6.8",
         "commander": "^12"
       },
@@ -656,6 +657,11 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@dev-build-deploy/version-it": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@dev-build-deploy/version-it/-/version-it-0.3.0.tgz",
+      "integrity": "sha512-wHT0XC3EPs0WxB62fgn6MdTrZQxYmbmWw1ISq3QKajVwNWOmu3FGKFzGud93lt3WUQfhXTFB1E3SE0BBK2hC1w=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -2032,12 +2038,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -3303,9 +3309,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@actions/core": "^1",
+    "@dev-build-deploy/version-it": "^0.3.0",
     "axios": "^1.6.8",
     "commander": "^12"
   },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+import { SemVer } from "@dev-build-deploy/version-it";
+
+import { Version } from "./jira";
+
+/**
+ * Check if the component is valid, incl.
+ * - No spaces
+ * - All lower case
+ *
+ * @param component - The component to check
+ * @returns - True if the component is valid, false otherwise
+ */
+export function isValidComponent(component?: string): boolean {
+  if (!component) {
+    return true;
+  }
+
+  return !component.includes(" ") && component === component.toLowerCase();
+}
+
+/**
+ * Check if the version is valid SemVer.
+ * @param version - The version to check
+ * @returns - True if the version is valid, false otherwise
+ */
+export function isSemver(version: string): boolean {
+  try {
+    new SemVer(version);
+  } catch (error) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Extracts the component name and version from the provided version name.
+ * @param version - The version name
+ * @returns - The component name and version
+ */
+export function getComponentVersion(version: string): { component?: string; version: string } {
+  const index = version.lastIndexOf("/");
+  if (index === -1) {
+    return { component: undefined, version };
+  }
+
+  const component = version.substring(0, index);
+  const versionStr = version.substring(index + 1);
+
+  if (!isValidComponent(component)) {
+    throw new Error(`Invalid component: ${component}`);
+  }
+
+  if (!isSemver(versionStr)) {
+    throw new Error(`Invalid Semantic Version: ${versionStr}`);
+  }
+
+  return { component, version: versionStr };
+}
+
+/**
+ * Creates a component version name from the provided component and version.
+ * @param component - The component name
+ * @param version - The version
+ * @returns - The component version name
+ * @throws - If the component or version is invalid
+ */
+export function setComponentVersion(version: string, component?: string): string {
+  if (!isValidComponent(component)) {
+    throw new Error(`Invalid component: ${component}`);
+  }
+
+  if (!isSemver(version)) {
+    throw new Error(`Invalid Semantic Version: ${version}`);
+  }
+
+  if (!component) {
+    return version;
+  }
+
+  return `${component}/${version}`;
+}
+
+/**
+ * Sorts the provided versions by component and version.
+ * @param versions - The versions to sort
+ * @returns - The sorted versions
+ */
+export function sortFixVersions(versions: Version[]): Version[] {
+  return [...versions]
+    .filter(v => {
+      return isSemver(getComponentVersion(v.name).version);
+    })
+    .sort((a, b) => {
+      return new SemVer(getComponentVersion(a.name).version).compareTo(new SemVer(getComponentVersion(b.name).version));
+    })
+    .sort((a, b) => {
+      return (getComponentVersion(b.name).component ?? "").localeCompare(getComponentVersion(a.name).component ?? "");
+    });
+}

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,217 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Version } from "../src/jira";
+import * as utils from "../src/utils";
+
+describe("isValidComponent", () => {
+  test("Valid Component", () => {
+    expect(utils.isValidComponent("component")).toBe(true);
+  });
+
+  test("Invalid Component", () => {
+    expect(utils.isValidComponent("Component")).toBe(false);
+  });
+
+  test("No Component", () => {
+    expect(utils.isValidComponent()).toBe(true);
+  });
+});
+
+describe("isSemver", () => {
+  test("Valid SemVer", () => {
+    expect(utils.isSemver("1.0.0")).toBe(true);
+  });
+
+  test("Invalid SemVer", () => {
+    expect(utils.isSemver("1.0")).toBe(false);
+  });
+});
+
+describe("getComponentVersion", () => {
+  test("Component Version", () => {
+    expect(utils.getComponentVersion("component/1.0.0")).toEqual({
+      component: "component",
+      version: "1.0.0",
+    });
+  });
+
+  test("No Component", () => {
+    expect(utils.getComponentVersion("1.0.0")).toEqual({
+      component: undefined,
+      version: "1.0.0",
+    });
+  });
+
+  test("Invalid Component", () => {
+    expect(() => {
+      utils.getComponentVersion("WRONG COMPONENT/1.0");
+    }).toThrowError("Invalid component: WRONG COMPONENT");
+  });
+
+  test("Invalid Semantic Version", () => {
+    expect(() => {
+      utils.getComponentVersion("component/1.0");
+    }).toThrowError("Invalid Semantic Version: 1.0");
+  });
+});
+
+describe("setComponentVersion", () => {
+  test("Set Component Version", () => {
+    expect(utils.setComponentVersion("1.0.0", "component")).toBe("component/1.0.0");
+  });
+
+  test("No Component", () => {
+    expect(utils.setComponentVersion("1.0.0")).toBe("1.0.0");
+  });
+});
+
+describe("sortFixVersions", () => {
+  test("Sort Versions", () => {
+    const versions: Version[] = [
+      {
+        id: "1",
+        name: "component/1.0.0",
+        self: "abc",
+        archived: false,
+        released: false,
+        projectId: 0,
+      },
+      {
+        id: "2",
+        name: "component/1.1.0",
+        self: "def",
+        archived: false,
+        released: false,
+        projectId: 0,
+      },
+      {
+        id: "3",
+        name: "component/1.0.1",
+        self: "ghi",
+        archived: false,
+        released: false,
+        projectId: 0,
+      },
+    ];
+
+    const sortedVersions: Version[] = [
+      {
+        id: "1",
+        name: "component/1.0.0",
+        self: "abc",
+        archived: false,
+        released: false,
+        projectId: 0,
+      },
+      {
+        id: "3",
+        name: "component/1.0.1",
+        self: "ghi",
+        archived: false,
+        released: false,
+        projectId: 0,
+      },
+      {
+        id: "2",
+        name: "component/1.1.0",
+        self: "def",
+        archived: false,
+        released: false,
+        projectId: 0,
+      },
+    ];
+    expect(utils.sortFixVersions(versions)).toStrictEqual(sortedVersions);
+  });
+
+  test("Sort Versions per Component", () => {
+    const versions: Version[] = [
+      {
+        id: "1",
+        name: "1.0.0",
+        self: "abc",
+        archived: false,
+        released: false,
+        projectId: 0,
+      },
+      {
+        id: "2",
+        name: "app/1.1.0",
+        self: "def",
+        archived: false,
+        released: false,
+        projectId: 0,
+      },
+      {
+        id: "3",
+        name: "app/1.0.1",
+        self: "ghi",
+        archived: false,
+        released: false,
+        projectId: 0,
+      },
+      {
+        id: "4",
+        name: "framework/3.0.0",
+        self: "jkl",
+        archived: false,
+        released: false,
+        projectId: 0,
+      },
+      {
+        id: "5",
+        name: "3.0.0",
+        self: "mno",
+        archived: false,
+        released: false,
+        projectId: 0,
+      },
+    ];
+
+    const sortedVersions: Version[] = [
+      {
+        id: "4",
+        name: "framework/3.0.0",
+        self: "jkl",
+        archived: false,
+        released: false,
+        projectId: 0,
+      },
+      {
+        id: "3",
+        name: "app/1.0.1",
+        self: "ghi",
+        archived: false,
+        released: false,
+        projectId: 0,
+      },
+      {
+        id: "2",
+        name: "app/1.1.0",
+        self: "def",
+        archived: false,
+        released: false,
+        projectId: 0,
+      },
+      {
+        id: "1",
+        name: "1.0.0",
+        self: "abc",
+        archived: false,
+        released: false,
+        projectId: 0,
+      },
+      {
+        id: "5",
+        name: "3.0.0",
+        self: "mno",
+        archived: false,
+        released: false,
+        projectId: 0,
+      },
+    ];
+    expect(utils.sortFixVersions(versions)).toStrictEqual(sortedVersions);
+  });
+});


### PR DESCRIPTION
New Releases will now be added in order of SemVer 2.0 precendence. This assumes that you current releases are already sorted, if this is not the case, you can use the CLI tool to sort all versions for you.

In addition, you can specify a component name for Jira projects maintaining multiple different products (i.e. `app/1.0.0` and `framework/2.1.3`)